### PR TITLE
Allow notifications to be delivered if there is no active activity

### DIFF
--- a/Module/src/bencoding/alarmmanager/AlarmManagerProxy.java
+++ b/Module/src/bencoding/alarmmanager/AlarmManagerProxy.java
@@ -31,6 +31,8 @@ public class AlarmManagerProxy extends KrollProxy {
 	private static final String LCAT = "AlarmManager";
 	private static final boolean FORCE_LOG = true;
 	private static final int DEFAULT_REQUEST_CODE = 192837;
+	public static String rootActivityClassName = "";
+
 	public AlarmManagerProxy() {
 		super();
 	}
@@ -108,6 +110,7 @@ public class AlarmManagerProxy extends KrollProxy {
 		intent.putExtra("notification_vibrate", doVibrate);
 		intent.putExtra("notification_show_lights", showLights);
 		intent.putExtra("notification_requestcode", requestCode);
+		intent.putExtra("notification_root_classname", rootActivityClassName);
 		return intent;
 	}
 	
@@ -345,5 +348,18 @@ public class AlarmManagerProxy extends KrollProxy {
 		}
 			
 		utils.msgLogger(LCAT, "Alarm Service Request Created",FORCE_LOG);	
+	}
+
+	@Kroll.method
+	public void setRootActivityClassName(@Kroll.argument(optional=true) Object className){
+		//
+		utils.msgLogger(LCAT, "Request to set rootActivityClassName", FORCE_LOG);
+
+		if (className != null) {
+			if (className instanceof String) {
+				utils.msgLogger(LCAT, "Setting rootActivityClassName to: " + className, FORCE_LOG);
+				rootActivityClassName = (String)className;
+			}
+		}
 	}
 }

--- a/Module/src/bencoding/alarmmanager/AlarmNotificationListener.java
+++ b/Module/src/bencoding/alarmmanager/AlarmNotificationListener.java
@@ -31,6 +31,8 @@ public class AlarmNotificationListener extends BroadcastReceiver {
     	utils.msgLogger(LCAT,"contentTitle is " + contentTitle);
     	String contentText = bundle.getString("notification_msg");
     	utils.msgLogger(LCAT,"contentText is " + contentText);
+    	String className = bundle.getString("notification_root_classname");
+    	utils.msgLogger(LCAT,"className is " + className);
     	boolean hasIcon = bundle.getBoolean("notification_has_icon", FORCE_LOG);
         int icon = R.drawable.stat_notify_more;        
         if(hasIcon){
@@ -49,14 +51,22 @@ public class AlarmNotificationListener extends BroadcastReceiver {
         
     	mNotificationManager =(NotificationManager) TiApplication.getInstance().getSystemService(TiApplication.NOTIFICATION_SERVICE);
     	utils.msgLogger(LCAT,"NotificationManager created");
-    	showNotification(TiApplication.getInstance().getApplicationContext(),contentTitle,contentText,icon,playSound,doVibrate,showLights); 	
+    	showNotification(TiApplication.getInstance().getApplicationContext(),contentTitle,contentText,icon,playSound,doVibrate,showLights,className); 	
     }
-    private void showNotification(Context context, String contentTitle, String contentText, int contentIcon, boolean playSound, boolean doVibrate, boolean showLights) {
+    private void showNotification(Context context, String contentTitle, String contentText, int contentIcon, boolean playSound, boolean doVibrate, boolean showLights, String className) {
     	utils.msgLogger(LCAT,"Building Notification");  
     	// MAKE SURE YOU HAVE android:launchMode="singleTask" SET IN YOUR TIAPP.XML FILE
     	// IF YOU DON'T HAVE THIS, IT WILL RESTART YOUR APP
     	// See the sample project for an example
-    	Intent intent = new Intent(TiApplication.getInstance().getApplicationContext(),TiApplication.getInstance().getRootOrCurrentActivity().getClass());    	
+		Intent intent = null;
+		try {
+			utils.msgLogger(LCAT,"Trying to get a class for name '" + className + "'");
+			Class intentClass = Class.forName(className);
+			intent = new Intent(TiApplication.getInstance().getApplicationContext(), intentClass);
+		} catch (ClassNotFoundException e) {
+			utils.msgLogger(LCAT,"Unable to get Class.forName '" + AlarmManagerProxy.rootActivityClassName + "', using getRootOrCurrentActivity() instead");
+			intent = new Intent(TiApplication.getInstance().getApplicationContext(),TiApplication.getInstance().getRootOrCurrentActivity().getClass());
+		}
     	Notification notification = new Notification(contentIcon, contentTitle, System.currentTimeMillis());		 
     	PendingIntent sender = PendingIntent.getActivity( TiApplication.getInstance().getApplicationContext(), 0, intent,  PendingIntent.FLAG_UPDATE_CURRENT | Notification.FLAG_AUTO_CANCEL);
     	


### PR DESCRIPTION
This allows Alarms to be re-created after a device reboot, and
notifications delievered if there is not currently an active
Activity for the app.

Some history:

Alarms dont't survive a reboot.  To get around this, we have a
module that adds a BOOT_COMPLETED receiver -- which starts a
service at boot time to re-create the alarms.
(See https://support.appcelerator.com/tickets/APP-539342)

However, if the app itself is not manually started after the reboot,
there is never an active activity.  The call to getRootOrCurrentActivity()
in showNotification() returns null and a NullPointerException
occurs (and the notification is never delivered.)

This patch adds the ability for the app to pass in the class name
of the activity that should be started when the notification is
delivered.  If no name is passed in, the old default behavior is
used.
