### PR TITLE
AlarmManagerProxy: fixed sound url

### DIFF
--- a/src/bencoding/alarmmanager/AlarmManagerProxy.java
+++ b/src/bencoding/alarmmanager/AlarmManagerProxy.java
@@ -99,7 +99,7 @@ public class AlarmManagerProxy extends KrollProxy {
 		}
 		
 		if (args.containsKey(TiC.PROPERTY_SOUND)){
-			notificationSound = TiConvert.toString(args, TiC.PROPERTY_SOUND);
+		    notificationSound = resolveUrl(null, TiConvert.toString(args, TiC.PROPERTY_SOUND));
 		}
 
 		Intent intent = new Intent(TiApplication.getInstance().getApplicationContext(), AlarmNotificationListener.class);


### PR DESCRIPTION
fixes custom sounds
now works for me with 

```
sound : Ti.Filesystem.getResRawDirectory() + 'foobar.mp3'; // with foobar.mp3 in PROJECT/platform/android/res/raw/
```

tested with TiSDK 3.2.2.GA and Android 4.2.1/4.3
