### PR TITLE
Updated logging in cancelAlarmNotification()

### DIFF
--- a/src/bencoding/alarmmanager/AlarmManagerProxy.java
+++ b/src/bencoding/alarmmanager/AlarmManagerProxy.java
@@ -139,7 +139,7 @@ public class AlarmManagerProxy extends KrollProxy {
 			}
 		}	
 
-		utils.debugLog("Cancelling requestCode = " + requestCode);	
+		utils.debugLog(String.format("Cancelling requestCode = {%d}", intentRequestCode));
 		
 		//Create a placeholder for the args value
 		HashMap<String, Object> placeholder = new HashMap<String, Object>(0);


### PR DESCRIPTION
Currently, the logging of the request code displays the un-parsed request code.  This can cause some funkiness if the JavaScript interacting with the module sends a request code that isn't a number ("12" instead of 12).  This change will allow the log to show the actual request code submitted to the AlarmManager.
